### PR TITLE
v0.2.0-alpha.1 – Scopes and Dirty Checking

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -31,7 +31,7 @@ module.exports = function (config) {
       }), ['aliasify', alias]],
       extensions: ['.js']
     },
-    reporters: ['progress', 'coverage'],
+    reporters: ['spec', 'coverage'],
     coverageReporter: {
       instrumenters: {isparta: require('isparta')},
       instrumenter: {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "karma-jasmine": "^1.1.0",
     "karma-jshint-preprocessor": "0.0.6",
     "karma-phantomjs-launcher": "^1.0.2",
+    "karma-spec-reporter": "0.0.26",
     "phantomjs-prebuilt": "^2.1.14",
     "rimraf": "^2.5.4",
     "sinon": "^1.17.7",

--- a/src/index.js
+++ b/src/index.js
@@ -1,1 +1,0 @@
-export default name => `Hello ${name}!`;

--- a/src/scope.js
+++ b/src/scope.js
@@ -82,6 +82,7 @@ export default class Scope {
     };
 
     this.$$watchers.push(watcher);
+    this.$$lastDirtyWatch = null;
   }
 
   /**

--- a/src/scope.js
+++ b/src/scope.js
@@ -1,0 +1,6 @@
+/**
+ * @class Scope
+ * @description Scopes can be created by applying the `new` operator to the
+ * `Scope` constructor.
+ */
+export default class Scope {}

--- a/src/scope.js
+++ b/src/scope.js
@@ -73,7 +73,7 @@ export default class Scope {
    * scope.$digest();
    * expect(scope.counter).toBe(2);
    */
-  $watch (watchExpression, listener) {
+  $watch (watchExpression, listener = () => {}) {
     const watcher = {
       watchExpression,
       listener,

--- a/src/scope.js
+++ b/src/scope.js
@@ -44,6 +44,22 @@ export default class Scope {
   uuid () {}
 
   /**
+   * @name Scope#isNumber
+   * @function
+   * @description Determines if a reference is a `Number`. This includes the
+   *     **special** numbers `NaN`.
+   *
+   * @param {(Number)} newValue - Number to compare.
+   * @param {(Number)} oldValue - Number to compare.
+   *
+   * @returns {Boolean} True if numbers are NaN.
+   */
+  isNumber (newValue, oldValue) {
+    return (typeof newValue === 'number' && typeof oldValue === 'number' &&
+      isNaN(newValue) && isNaN(oldValue));
+  }
+
+  /**
    * @name Scope#$$areEqual
    * @function
    * @description Determines if two objects or two values are equivalent. Two
@@ -64,7 +80,7 @@ export default class Scope {
     if (equality)
       return _.isEqual(newValue, oldValue);
 
-    return newValue === oldValue;
+    return (newValue === oldValue) || this.isNumber(newValue, oldValue);
   }
 
   /**

--- a/src/scope.js
+++ b/src/scope.js
@@ -21,16 +21,17 @@ export default class Scope {
    *
    * @property {Array} $$watchers - A place to store all the watchers that
    *     have been registered.
+   * @property {Object} $$lastDirtyWatch - Keep track of the last dirty watch.
    */
   constructor () {
     /**
      * @description The double-dollar prefix `$$` means that this variable
      *     should be considered private to the framework, and should not be
      *     called from application code.
-     * type {Array}
      * @readonly
      */
     this.$$watchers = [];
+    this.$$lastDirtyWatch = null;
   }
 
   /**
@@ -104,11 +105,14 @@ export default class Scope {
       oldValue = watcher.last;
 
       if (newValue !== oldValue) {
+        this.$$lastDirtyWatch = watcher;
         watcher.last = newValue;
         watcher.listener(newValue,
           (oldValue === this.uuid ? newValue : oldValue),
           this);
         dirty = true;
+      } else if (this.$$lastDirtyWatch === watcher) {
+        return false;
       }
     });
 
@@ -144,6 +148,8 @@ export default class Scope {
   $digest () {
     let dirty;
     let TTL = 10;
+
+    this.$$lastDirtyWatch = null;
 
     do {
       dirty = this.$$digestOnce();

--- a/src/scope.js
+++ b/src/scope.js
@@ -120,7 +120,9 @@ export default class Scope {
 
       if (newValue !== oldValue) {
         watcher.last = newValue;
-        watcher.listener(newValue, oldValue, this);
+        watcher.listener(newValue,
+          (oldValue === this.uuid ? newValue : oldValue),
+          this);
       }
     });
   }

--- a/src/scope.js
+++ b/src/scope.js
@@ -160,20 +160,22 @@ export default class Scope {
 
     _.forEachRight(this.$$watchers, watcher => {
       try {
-        // $digest has to remember what the last value of each `watch` function
-        // was.
-        newValue = watcher.watchExpression(this);
-        oldValue = watcher.last;
+        if (watcher) {
+          // $digest has to remember what the last value of each `watch` function
+          // was.
+          newValue = watcher.watchExpression(this);
+          oldValue = watcher.last;
 
-        if (!this.$$areEqual(newValue, oldValue, watcher.equality)) {
-          this.$$lastDirtyWatch = watcher;
-          watcher.last = (watcher.equality ? _.cloneDeep(newValue) : newValue);
-          watcher.listener(newValue,
-            (oldValue === this.uuid ? newValue : oldValue),
-            this);
-          dirty = true;
-        } else if (this.$$lastDirtyWatch === watcher) {
-          return false;
+          if (!this.$$areEqual(newValue, oldValue, watcher.equality)) {
+            this.$$lastDirtyWatch = watcher;
+            watcher.last = (watcher.equality ? _.cloneDeep(newValue) : newValue);
+            watcher.listener(newValue,
+              (oldValue === this.uuid ? newValue : oldValue),
+              this);
+            dirty = true;
+          } else if (this.$$lastDirtyWatch === watcher) {
+            return false;
+          }
         }
       } catch (e) {
         console.error(e);

--- a/src/scope.js
+++ b/src/scope.js
@@ -50,7 +50,7 @@ export default class Scope {
    * @param {(string|function)} watchExpression - The `watchExpression` is called
    *     on every call to `$digest()` and should return the value that will be
    *     watched.
-   * @param {function} listener - The `listener` is called only when the value from
+   * @param {function} [listener] - The `listener` is called only when the value from
    *     the current `watchExpression` and the previous call to `watchExpression`
    *     are not equal.
    *
@@ -84,6 +84,38 @@ export default class Scope {
   }
 
   /**
+   * @name Scope#$$digestOnce
+   * @function
+   * @description Runs all the watchers once, and returns a boolean value that
+   *     determines whether there any changes or not.
+   * @returns {Boolean} Value that determine if a watcher is dirty or not.
+   * @readonly
+   *
+   * @example
+   * const dirty = $$digestOnce();
+   */
+  $$digestOnce () {
+    let newValue, oldValue, dirty;
+
+    _.forEach(this.$$watchers, watcher => {
+      // $digest has to remember what the last value of each `watch` function
+      // was.
+      newValue = watcher.watchExpression(this);
+      oldValue = watcher.last;
+
+      if (newValue !== oldValue) {
+        watcher.last = newValue;
+        watcher.listener(newValue,
+          (oldValue === this.uuid ? newValue : oldValue),
+          this);
+        dirty = true;
+      }
+    });
+
+    return dirty;
+  }
+
+  /**
    * @name Scope#$digest
    * @function
    * @description Iterates over all registered watchers and calls their listener
@@ -110,20 +142,10 @@ export default class Scope {
    * expect(scope.counter).toBe(2);
    */
   $digest () {
-    let newValue, oldValue;
+    let dirty;
 
-    _.forEach(this.$$watchers, watcher => {
-      // $digest has to remember what the last value of each `watch` function
-      // was.
-      newValue = watcher.watchExpression(this);
-      oldValue = watcher.last;
-
-      if (newValue !== oldValue) {
-        watcher.last = newValue;
-        watcher.listener(newValue,
-          (oldValue === this.uuid ? newValue : oldValue),
-          this);
-      }
-    });
+    do {
+      dirty = this.$$digestOnce();
+    } while (dirty);
   }
 }

--- a/src/scope.js
+++ b/src/scope.js
@@ -7,7 +7,7 @@ import _ from 'lodash';
  *     `Scope` constructor.
  * @type {Class}
  * @since 1.0.0
- * @author rogues <@ro9ues>
+ * @author rogues {@link https://twitter.com/ro9ues @ro9ues}
  * @example
  * const scope = new Scope();
  */
@@ -100,6 +100,7 @@ export default class Scope {
    */
   $digest () {
     _.forEach(this.$$watchers, watcher => {
+      watcher.watchExpression(this);
       watcher.listener();
     });
   }

--- a/src/scope.js
+++ b/src/scope.js
@@ -139,6 +139,7 @@ export default class Scope {
 
       if (index >= 0) {
         this.$$watchers.splice(index, 1);
+        this.$$lastDirtyWatch = null;
       }
     };
   }

--- a/src/scope.js
+++ b/src/scope.js
@@ -143,9 +143,14 @@ export default class Scope {
    */
   $digest () {
     let dirty;
+    let TTL = 10;
 
     do {
       dirty = this.$$digestOnce();
+
+      if (dirty && !(TTL--)) {
+        throw 'ngException: TTL max–iterations has been reached.';
+      }
     } while (dirty);
   }
 }

--- a/src/scope.js
+++ b/src/scope.js
@@ -13,6 +13,7 @@ import _ from 'lodash';
  * const scope = new Scope();
  */
 export default class Scope {
+
   /**
    * @constructs Scope#constructor
    * @description Create an instance of `Scope`.
@@ -126,7 +127,7 @@ export default class Scope {
       last: this.uuid,
     };
 
-    this.$$watchers.push(watcher);
+    this.$$watchers.unshift(watcher);
 
     this.$$lastDirtyWatch = null;
 
@@ -156,7 +157,7 @@ export default class Scope {
   $$digestOnce () {
     let newValue, oldValue, dirty;
 
-    _.forEach(this.$$watchers, watcher => {
+    _.forEachRight(this.$$watchers, watcher => {
       try {
         // $digest has to remember what the last value of each `watch` function
         // was.

--- a/src/scope.js
+++ b/src/scope.js
@@ -1,6 +1,106 @@
+import _ from 'lodash';
 /**
+ * @namespace Scope
  * @class Scope
+ * @name Scope
  * @description Scopes can be created by applying the `new` operator to the
- * `Scope` constructor.
+ *     `Scope` constructor.
+ * @type {Class}
+ * @since 1.0.0
+ * @author rogues <@ro9ues>
+ * @example
+ * const scope = new Scope();
  */
-export default class Scope {}
+export default class Scope {
+  /**
+   * @constructs Scope#constructor
+   * @description Create an instance of `Scope`.
+   * @function
+   * @instance
+   *
+   * @property {Array} $$watchers - A place to store all the watchers that
+   *     have been registered.
+   */
+  constructor () {
+    /**
+     * @description The double-dollar prefix `$$` means that this variable
+     *     should be considered private to the framework, and should not be
+     *     called from application code.
+     * type {Array}
+     * @readonly
+     */
+    this.$$watchers = [];
+  }
+
+  /**
+   * @name Scope#$watch
+   * @function
+   * @description Register a `listener` callback to be executed whenever the
+   *     `watchExpression` changes.
+   * @param {(string|function)} watchExpression - The `watchExpression` is called
+   *     on every call to `$digest()` and should return the value that will be
+   *     watched.
+   * @param {function} listener - The `listener` is called only when the value from
+   *     the current `watchExpression` and the previous call to `watchExpression`
+   *     are not equal.
+   *
+   * @example
+   * scope.someValue = 'a';
+   * scope.counter = 0;
+   *
+   * scope.$watch(
+   *   scope => scope.someValue,
+   *   (newValue, oldValue, scope) => { scope.counter++; }
+   * );
+   *
+   * expect(scope.counter).toBe(0);
+   *
+   * scope.$digest();
+   * expect(scope.counter).toBe(1);
+   *
+   * scope.someValue = 'b';
+   *
+   * scope.$digest();
+   * expect(scope.counter).toBe(2);
+   */
+  $watch (watchExpression, listener) {
+    const watcher = {
+      watchExpression,
+      listener
+    };
+
+    this.$$watchers.push(watcher);
+  }
+
+  /**
+   * @name Scope#$digest
+   * @function
+   * @description Iterates over all registered watchers and calls their listener
+   *     functions on the current `Scope`.
+   * @function
+   *
+   * @example
+   * scope.someValue = 'a';
+   * scope.counter = 0;
+   *
+   * scope.$watch(
+   *   scope => scope.someValue,
+   *   (newValue, oldValue, scope) => { scope.counter++; }
+   * );
+   *
+   * expect(scope.counter).toBe(0);
+   *
+   * scope.$digest();
+   * expect(scope.counter).toBe(1);
+   *
+   * scope.someValue = 'b';
+   *
+   * scope.$digest();
+   * expect(scope.counter).toBe(2);
+   */
+  $digest () {
+    _.forEach(this.$$watchers, watcher => {
+      watcher.listener();
+    });
+  }
+}

--- a/src/scope.js
+++ b/src/scope.js
@@ -1,4 +1,5 @@
 import _ from 'lodash';
+
 /**
  * @namespace Scope
  * @class Scope
@@ -99,9 +100,18 @@ export default class Scope {
    * expect(scope.counter).toBe(2);
    */
   $digest () {
+    let newValue, oldValue;
+
     _.forEach(this.$$watchers, watcher => {
-      watcher.watchExpression(this);
-      watcher.listener();
+      // $digest has to remember what the last value of each `watch` function
+      // was.
+      newValue = watcher.watchExpression(this);
+      oldValue = watcher.last;
+
+      if (newValue !== oldValue) {
+        watcher.last = newValue;
+        watcher.listener(newValue, oldValue, this);
+      }
     });
   }
 }

--- a/src/scope.js
+++ b/src/scope.js
@@ -141,20 +141,24 @@ export default class Scope {
     let newValue, oldValue, dirty;
 
     _.forEach(this.$$watchers, watcher => {
-      // $digest has to remember what the last value of each `watch` function
-      // was.
-      newValue = watcher.watchExpression(this);
-      oldValue = watcher.last;
+      try {
+        // $digest has to remember what the last value of each `watch` function
+        // was.
+        newValue = watcher.watchExpression(this);
+        oldValue = watcher.last;
 
-      if (!this.$$areEqual(newValue, oldValue, watcher.equality)) {
-        this.$$lastDirtyWatch = watcher;
-        watcher.last = (watcher.equality ? _.cloneDeep(newValue) : newValue);
-        watcher.listener(newValue,
-          (oldValue === this.uuid ? newValue : oldValue),
-          this);
-        dirty = true;
-      } else if (this.$$lastDirtyWatch === watcher) {
-        return false;
+        if (!this.$$areEqual(newValue, oldValue, watcher.equality)) {
+          this.$$lastDirtyWatch = watcher;
+          watcher.last = (watcher.equality ? _.cloneDeep(newValue) : newValue);
+          watcher.listener(newValue,
+            (oldValue === this.uuid ? newValue : oldValue),
+            this);
+          dirty = true;
+        } else if (this.$$lastDirtyWatch === watcher) {
+          return false;
+        }
+      } catch (e) {
+        console.error(e);
       }
     });
 

--- a/src/scope.js
+++ b/src/scope.js
@@ -34,6 +34,15 @@ export default class Scope {
   }
 
   /**
+   * @name Scope#uuid
+   * @function
+   * @description Function to initialize the `last` attribute to something we
+   *     can guarantee to be unique, so that’s different from anything a watch
+   *     function might return, including `undefined`.
+   */
+  uuid () {}
+
+  /**
    * @name Scope#$watch
    * @function
    * @description Register a `listener` callback to be executed whenever the
@@ -67,7 +76,8 @@ export default class Scope {
   $watch (watchExpression, listener) {
     const watcher = {
       watchExpression,
-      listener
+      listener,
+      last: this.uuid,
     };
 
     this.$$watchers.push(watcher);

--- a/src/scope.js
+++ b/src/scope.js
@@ -88,12 +88,16 @@ export default class Scope {
    * @function
    * @description Register a `listener` callback to be executed whenever the
    *     `watchExpression` changes.
-   * @param {(string|function)} watchExpression - The `watchExpression` is called
-   *     on every call to `$digest()` and should return the value that will be
-   *     watched.
-   * @param {function} [listener] - The `listener` is called only when the value from
-   *     the current `watchExpression` and the previous call to `watchExpression`
-   *     are not equal.
+   * @param {(string|function)} watchExpression - The `watchExpression` is
+   *     called on every call to `$digest()` and should return the value that
+   *     will be watched.
+   * @param {function} [listener=function] - The `listener` is called only when the value
+   *     from the current `watchExpression` and the previous call to
+   *     `watchExpression` are not equal.
+   * @param {Boolean} [equality=false] - Compare for object equality using
+   *     {@link Scope#$$areEqual areEqual} instead of comparing for reference equality.
+   *
+   * @returns {function} Returns a deregistration function for this listener.
    *
    * @example
    * scope.someValue = 'a';
@@ -123,7 +127,19 @@ export default class Scope {
     };
 
     this.$$watchers.push(watcher);
+
     this.$$lastDirtyWatch = null;
+
+    // @name Scope#deregisterWatch
+    // @function
+    // @description Removes `watch` from the `$$watchers` array.
+    return () => {
+      const index = this.$$watchers.indexOf(watcher);
+
+      if (index >= 0) {
+        this.$$watchers.splice(index, 1);
+      }
+    };
   }
 
   /**

--- a/tests/sayHello.spec.js
+++ b/tests/sayHello.spec.js
@@ -1,7 +1,0 @@
-import sayHello from 'src/index';
-
-describe('sayHello function', () => {
-  it('returns a salute', () => {
-    expect(sayHello('ro9ues')).toBe('Hello ro9ues!');
-  });
-});

--- a/tests/scope.spec.js
+++ b/tests/scope.spec.js
@@ -1,0 +1,10 @@
+import Scope from 'src/scope';
+
+describe('Scope', () => {
+  it('can be constructed and used as an object', () => {
+    const scope = new Scope();
+    scope.aProperty = 1;
+
+    expect(scope.aProperty).toBe(1);
+  });
+});

--- a/tests/scope.spec.js
+++ b/tests/scope.spec.js
@@ -215,5 +215,23 @@ describe('Scope', () => {
       scope.$digest();
       expect(scope.counter).toBe(2);
     });
+
+    it('correctly handles NaNs', () => {
+      scope.number  = 0/0;
+      scope.counter = 0;
+
+      scope.$watch(
+        scope => scope.number,
+        (newValue, oldValue, scope) => {
+          scope.counter++;
+        }
+      );
+
+      scope.$digest();
+      expect(scope.counter).toBe(1);
+
+      scope.$digest();
+      expect(scope.counter).toBe(1);
+    });
   });
 });

--- a/tests/scope.spec.js
+++ b/tests/scope.spec.js
@@ -332,5 +332,32 @@ describe('Scope', () => {
       scope.$digest();
       expect(watchExecutions).toEqual(['first', 'second', 'third', 'first', 'third']);
     });
+
+    it('allows a $watch to destroy another during $digest', () => {
+      scope.aValue  = 'a';
+      scope.counter = 0;
+
+      scope.$watch(
+        scope => scope.aValue,
+        (newValue, oldValue, scope) => {
+          unbindWatcher();
+        }
+      );
+
+      const unbindWatcher = scope.$watch(
+        scope => {},
+        (newValue, oldValue, scope) => {}
+      );
+
+      scope.$watch(
+        scope => scope.aValue,
+        (newValue, oldValue, scope) => {
+          scope.counter++;
+        }
+      );
+
+      scope.$digest();
+      expect(scope.counter).toBe(1);
+    });
   });
 });

--- a/tests/scope.spec.js
+++ b/tests/scope.spec.js
@@ -233,5 +233,25 @@ describe('Scope', () => {
       scope.$digest();
       expect(scope.counter).toBe(1);
     });
+
+    it('catches exceptions in watch functions and continues', () => {
+      scope.aValue  = 'abc';
+      scope.counter = 0;
+
+      scope.$watch(
+        scope => { throw 'ngError'; },
+        (newValue, oldValue, scope) => {}
+      );
+
+      scope.$watch(
+        scope => scope.aValue,
+        (newValue, oldValue, scope) => {
+          scope.counter++;
+        }
+      );
+
+      scope.$digest();
+      expect(scope.counter).toBe(1);
+    });
   });
 });

--- a/tests/scope.spec.js
+++ b/tests/scope.spec.js
@@ -275,5 +275,31 @@ describe('Scope', () => {
       scope.$digest();
       expect(scope.counter).toBe(1);
     });
+
+    it('allows destroying a $watch with a removal function', () => {
+      scope.aValue  = 'a';
+      scope.counter = 0;
+
+      const unbindWatcher = scope.$watch(
+        scope => scope.aValue,
+        (newValue, oldValue, scope) => {
+          scope.counter++;
+        }
+      );
+
+      scope.$digest();
+      expect(scope.counter).toBe(1);
+
+      scope.aValue = 'b';
+
+      scope.$digest();
+      expect(scope.counter).toBe(2);
+
+      scope.aValue = 'c';
+      unbindWatcher();
+
+      scope.$digest();
+      expect(scope.counter).toBe(2);
+    });
   });
 });

--- a/tests/scope.spec.js
+++ b/tests/scope.spec.js
@@ -98,5 +98,35 @@ describe('Scope', () => {
 
       expect(watchExpression).toHaveBeenCalled();
     });
+
+    it('triggers chained watchers in the same $digest', () => {
+      scope.name = 'rogues';
+
+      scope.$watch(
+        scope => scope.nameUpper,
+        (newValue, oldValue, scope) => {
+          if (newValue) {
+            scope.initial = `${newValue.substring(0, 1)}.`;
+          }
+        }
+      );
+
+      scope.$watch(
+        scope => scope.name,
+        (newValue, oldValue, scope) => {
+          if (newValue) {
+            scope.nameUpper = newValue.toUpperCase();
+          }
+        }
+      );
+
+      scope.$digest();
+      expect(scope.initial).toBe('R.');
+
+      scope.name = 'genius';
+
+      scope.$digest();
+      expect(scope.initial).toBe('G.');
+    });
   });
 });

--- a/tests/scope.spec.js
+++ b/tests/scope.spec.js
@@ -174,5 +174,25 @@ describe('Scope', () => {
       scope.$digest();
       expect(watchExecutions).toBe(301);
     });
+
+    it('does not end $digest so that new watches are not run', () => {
+      scope.aValue  = 'abc';
+      scope.counter = 0;
+
+      scope.$watch(
+        scope => scope.aValue,
+        (newValue, oldValue, scope) => {
+          scope.$watch(
+            scope => scope.aValue,
+            (newValue, oldValue, scope) => {
+              scope.counter++;
+            }
+          );
+        }
+      );
+
+      scope.$digest();
+      expect(scope.counter).toBe(1);
+    });
   });
 });

--- a/tests/scope.spec.js
+++ b/tests/scope.spec.js
@@ -60,5 +60,19 @@ describe('Scope', () => {
       scope.$digest();
       expect(scope.counter).toBe(2);
     });
+
+    it('calls listener when watch value is first undefined', () => {
+      scope.counter = 0;
+
+      scope.$watch(
+        scope => scope.someValue,
+        (newValue, oldValue, scope) => {
+          scope.counter++;
+        }
+      );
+      scope.$digest();
+
+      expect(scope.counter).toBe(1);
+    });
   });
 });

--- a/tests/scope.spec.js
+++ b/tests/scope.spec.js
@@ -74,5 +74,20 @@ describe('Scope', () => {
 
       expect(scope.counter).toBe(1);
     });
+
+    it('calls listener with new value as old value the first time', () => {
+      let newValueAsOldValue;
+      scope.someValue = 123;
+
+      scope.$watch(
+        scope => scope.someValue,
+        (newValue, oldValue, scope) => {
+          newValueAsOldValue = oldValue;
+        }
+      );
+
+      scope.$digest();
+      expect(newValueAsOldValue).toBe(123);
+    });
   });
 });

--- a/tests/scope.spec.js
+++ b/tests/scope.spec.js
@@ -359,5 +359,27 @@ describe('Scope', () => {
       scope.$digest();
       expect(scope.counter).toBe(1);
     });
+
+    it('allows destroying several $watches during $digest', () => {
+      scope.aValue  = 'a';
+      scope.counter = 0;
+
+      const unbindWatcher1 = scope.$watch(
+        scope => {
+          unbindWatcher1();
+          unbindWatcher2();
+        }
+      );
+
+      const unbindWatcher2 = scope.$watch(
+        scope => scope.aValue,
+        (newValue, oldValue, scope) => {
+          scope.counter++;
+        }
+      );
+
+      scope.$digest();
+      expect(scope.counter).toBe(0);
+    });
   });
 });

--- a/tests/scope.spec.js
+++ b/tests/scope.spec.js
@@ -301,5 +301,36 @@ describe('Scope', () => {
       scope.$digest();
       expect(scope.counter).toBe(2);
     });
+
+    it('allows destroying a $watch during $digest', () => {
+      const watchExecutions = [];
+      scope.aValue = 'a';
+
+      scope.$watch(
+        scope => {
+          watchExecutions.push('first');
+
+          return scope.aValue;
+        }
+      );
+
+      const unbindWatcher = scope.$watch(
+        scope => {
+          watchExecutions.push('second');
+          unbindWatcher();
+        }
+      );
+
+      scope.$watch(
+        scope => {
+          watchExecutions.push('third');
+
+          return scope.aValue;
+        }
+      );
+
+      scope.$digest();
+      expect(watchExecutions).toEqual(['first', 'second', 'third', 'first', 'third']);
+    });
   });
 });

--- a/tests/scope.spec.js
+++ b/tests/scope.spec.js
@@ -1,4 +1,5 @@
-import Scope from 'src/scope';
+import _      from 'lodash';
+import Scope  from 'src/scope';
 
 describe('Scope', () => {
   it('can be constructed and used as an object', () => {
@@ -148,6 +149,30 @@ describe('Scope', () => {
       );
 
       expect(() => { scope.$digest(); }).toThrow();
+    });
+
+    it('ends the $digest when the last watch is clean', () => {
+      let watchExecutions = 0;
+      scope.watches = _.range(100);
+
+      _.times(100, i => {
+        scope.$watch(
+          scope => {
+            watchExecutions++;
+
+            return scope.watches[i];
+          },
+          (newValue, oldValue, scope) => {}
+        );
+      });
+
+      scope.$digest();
+      expect(watchExecutions).toBe(200);
+
+      scope.watches[0] = 'Cuak';
+
+      scope.$digest();
+      expect(watchExecutions).toBe(301);
     });
   });
 });

--- a/tests/scope.spec.js
+++ b/tests/scope.spec.js
@@ -128,5 +128,26 @@ describe('Scope', () => {
       scope.$digest();
       expect(scope.initial).toBe('G.');
     });
+
+    it('gives up on the watches after 10 iterations', () => {
+      scope.counterA = 0;
+      scope.counterB = 0;
+
+      scope.$watch(
+        scope => scope.counterA,
+        (newValue, oldValue, scope) => {
+          scope.counterB++;
+        }
+      );
+
+      scope.$watch(
+        scope => scope.counterB,
+        (newValue, oldValue, scope) => {
+          scope.counterA++;
+        }
+      );
+
+      expect(() => { scope.$digest(); }).toThrow();
+    });
   });
 });

--- a/tests/scope.spec.js
+++ b/tests/scope.spec.js
@@ -34,5 +34,31 @@ describe('Scope', () => {
 
       expect(watchExpression).toHaveBeenCalledWith(scope);
     });
+
+    it('calls the listener function when the watched value changes', () => {
+      scope.someValue = 'a';
+      scope.counter   = 0;
+
+      scope.$watch(
+        scope => scope.someValue,
+        (newValue, oldValue, scope) => {
+          scope.counter++;
+        }
+      );
+
+      expect(scope.counter).toBe(0);
+
+      scope.$digest();
+      expect(scope.counter).toBe(1);
+
+      scope.$digest();
+      expect(scope.counter).toBe(1);
+
+      scope.someValue = 'b';
+      expect(scope.counter).toBe(1);
+
+      scope.$digest();
+      expect(scope.counter).toBe(2);
+    });
   });
 });

--- a/tests/scope.spec.js
+++ b/tests/scope.spec.js
@@ -7,4 +7,22 @@ describe('Scope', () => {
 
     expect(scope.aProperty).toBe(1);
   });
+
+  describe('$digest', () => {
+    let scope;
+
+    beforeEach(() => {
+      scope = new Scope();
+    });
+
+    it('calls the listener function of a watch on first $digest', () => {
+      const watchExpression = () => 'watchExpression';
+      const listener        = jasmine.createSpy();
+
+      scope.$watch(watchExpression, listener);
+      scope.$digest();
+
+      expect(listener).toHaveBeenCalled();
+    });
+  });
 });

--- a/tests/scope.spec.js
+++ b/tests/scope.spec.js
@@ -194,5 +194,26 @@ describe('Scope', () => {
       scope.$digest();
       expect(scope.counter).toBe(1);
     });
+
+    it('compares based on value if enabled', () => {
+      scope.aValue  = [1, 2, 3];
+      scope.counter = 0;
+
+      scope.$watch(
+        scope => scope.aValue,
+        (newValue, oldValue, scope) => {
+          scope.counter++;
+        },
+        true
+      );
+
+      scope.$digest();
+      expect(scope.counter).toBe(1);
+
+      scope.aValue.push(4);
+
+      scope.$digest();
+      expect(scope.counter).toBe(2);
+    });
   });
 });

--- a/tests/scope.spec.js
+++ b/tests/scope.spec.js
@@ -24,5 +24,15 @@ describe('Scope', () => {
 
       expect(listener).toHaveBeenCalled();
     });
+
+    it('calls the watch function with the scope as the argument', () => {
+      const watchExpression = jasmine.createSpy();
+      const listener        = () => {};
+
+      scope.$watch(watchExpression, listener);
+      scope.$digest();
+
+      expect(watchExpression).toHaveBeenCalledWith(scope);
+    });
   });
 });

--- a/tests/scope.spec.js
+++ b/tests/scope.spec.js
@@ -253,5 +253,27 @@ describe('Scope', () => {
       scope.$digest();
       expect(scope.counter).toBe(1);
     });
+
+    it('catches exceptions in listener functions and continues', () => {
+      scope.aValue  = 'abc';
+      scope.counter = 0;
+
+      scope.$watch(
+        scope => scope.aValue,
+        (newValue, oldValue, scope) => {
+          throw 'ngError';
+        }
+      );
+
+      scope.$watch(
+        scope => scope.aValue,
+        (newValue, oldValue, scope) => {
+          scope.counter++;
+        }
+      );
+
+      scope.$digest();
+      expect(scope.counter).toBe(1);
+    });
   });
 });

--- a/tests/scope.spec.js
+++ b/tests/scope.spec.js
@@ -89,5 +89,14 @@ describe('Scope', () => {
       scope.$digest();
       expect(newValueAsOldValue).toBe(123);
     });
+
+    it('may have watchers that omit the listener function', () => {
+      const watchExpression = jasmine.createSpy().and.returnValue('whatever');
+
+      scope.$watch(watchExpression);
+      scope.$digest();
+
+      expect(watchExpression).toHaveBeenCalled();
+    });
   });
 });


### PR DESCRIPTION
A perfectly usable implementation of an `Angular`–style `dirty-checking` scope system.

---

### Issues Addressed

- [x] [#2 – Scopes and Dirty–Checking](https://github.com/ro9ues/angular/issues/2)

###### All issues in milestone: [2. Scopes](https://github.com/ro9ues/angular/milestone/2)

---

### Release Checklist

- [x] [[`90ca132`]](https://github.com/ro9ues/angular/commit/90ca132d5a7bd50366c8576451ca9b74d61140b0) – **scope**: Scope can be constructed and used as an object.
- [x] [[`a0d855f`]](https://github.com/ro9ues/angular/commit/a0d855f27482b936d68a9d0ee7641ead5445b451) – **scope**: Watching Object Properties: `$watch` and `$digest`.
- [x] [[`56347e5`]](https://github.com/ro9ues/angular/commit/56347e5e5a5db290617f0459f440922e8dc8e5ad) – **scope**: Calls the watch function with the scope as the argument.
- [x] [[`6c19881`]](https://github.com/ro9ues/angular/commit/6c19881a4108b31c8cc6353d420ee671014eff9a) – **scope**: Calls the listener function when the watched value changes.
- [x] [[`461b94a`]](https://github.com/ro9ues/angular/commit/461b94a0599abf8372ba558935ee525a4ef978c0) – **scope**: Calls listener when watch value is first undefined.
- [x] [[`f2c3b3c`]](https://github.com/ro9ues/angular/commit/f2c3b3c070efdae6f77073ab9b5f830cc9057f40) – **scope**: Calls listener with new value as old value the first time.
- [x] [[`3245ace`]](https://github.com/ro9ues/angular/commit/3245ace546ed5580a186d0423e2f28cfb5b24fa4) – **scope**: May have watchers that omit the listener function.
- [x] [[`6544c6c`]](https://github.com/ro9ues/angular/commit/6544c6c6cdae9156e13badbf4ce5cd079b332e87) – **scope**: Triggers chained watchers in the same digest.
- [x] [[`6d5373a`]](https://github.com/ro9ues/angular/commit/6d5373adf330d5e9f0adbd9210571d913c9139ba) – **scope**: Giving up on an unstable `$digest`.
- [x] [[`fb8be96`]](https://github.com/ro9ues/angular/commit/fb8be96c8d2732f3a544087a2a7b904a657bb1e0) – **scope**: Short–circuiting the `$digest` when the last watch is clean.
- [x] [[`e59de3a`]](https://github.com/ro9ues/angular/commit/e59de3a9c2d04d416b6212a8d2c3cd130deadbf1) – **scope**: Does not end so that new watches are not run.
- [x] [[`675bc82`]](https://github.com/ro9ues/angular/commit/675bc82dc7d0ba219ea0cdf7ecbf476d7b28094d) – **scope**: Compares based on value if enabled.
- [x] [[`258e636`]](https://github.com/ro9ues/angular/commit/258e63624e9c1936564306e90465a6aa9942e8d0) – **scope**: Correctly handles NaNs.
- [x] [[`e8eb1d8`]](https://github.com/ro9ues/angular/commit/e8eb1d8af698b00c07d47657e38ea9b825426862) – **scope**: Catches exceptions in watch functions and continues.
- [x] [[`f490a8b`]](https://github.com/ro9ues/angular/commit/f490a8b94ce9e9d8bd85e201f375c5416f5b6add) – **scope**: Catches exceptions in listener functions and continues.
- [x] [[`f707a4c`]](https://github.com/ro9ues/angular/commit/f707a4cdf6fe5efc3f74225657d2ca381f694d21) – **scope**: Allows destroying a $watch with a removal function.
- [x] [[`3062a04`]](https://github.com/ro9ues/angular/commit/3062a0474139266f6be39d37ea3f5590aa47d970) – **digest**: Allows destroying a $watch during $digest.
- [x] [[`c029a8a`]](https://github.com/ro9ues/angular/commit/c029a8a66010b27c4165584ae19b6ce0f5a5bbb7) – **digest**: Allows a $watch to destroy another during $digest.
- [x] [[`b8a62ef`]](https://github.com/ro9ues/angular/commit/b8a62ef8dc1fe8b747644955e4a1acfb38ec43b4) – **digest**: Allows destroying several $watches during $digest.

---

### Approvals

- [x] Final approval @ro9ues